### PR TITLE
cmake, git: fix cyclic include issue and add clang related files into gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build/
 .vscode/
 CMakeUserPresets.json
 .vs/
+.cache/
+compile_commands.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 .vscode/
+CMakePresets.json
 CMakeUserPresets.json
 .vs/
 .cache/

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,6 +1,0 @@
-{
-  "version": 4,
-  "include": [
-    "CMakeUserPresets.json"
-  ]
-}


### PR DESCRIPTION
This PR removes the `CMakePresets.json` file to solve the cyclic include issue of `cmake --preset conan-release` and puts it into gitignore file. This issue happens when Conan generate the `CMakeUserPresets.json` file and cmake cannot run because both cmake preset files includes each other.
Also i added `.cache` and `compile_commands.json` file to gitignore because these files are only needed locally by clang for development and should not be in repo.